### PR TITLE
Bug: Fix the incorrect function call in http_realworld_server.py

### DIFF
--- a/streamvln/http_realworld_server.py
+++ b/streamvln/http_realworld_server.py
@@ -94,10 +94,10 @@ def eval_vln():
     for i in range(4):
         t1 = time.time()
         depth = np.zeros((image.shape[0], image.shape[1], 1))
-        return_action, generate_time, return_llm_output = evaluator.eval_action(0,
+        return_action, generate_time, return_llm_output = evaluator.step(0,
                                         image,
-                                        depth,
-                                        camera_pose,
+                                        #depth,
+                                        #camera_pose,
                                         instruction,
                                         run_model=(evaluator.step_id % 4 == 0))
         llm_output = return_llm_output if return_llm_output is not None else llm_output


### PR DESCRIPTION
In the file `http_realworld_server.py`, there is a reminder indicating insufficient parameters for `eval_action()`. Upon inspection, `eval_action()` is defined in `streamvln_eval.py`, which only takes one parameter, `idx`, and its code logic is only applicable to simulation. Obviously, there are six parameters here (in fact, `depth` and `camera_pose` are currently not used), so it should be calling the `step()` function from `streamvln_agent.py`, which happens to have four parameters corresponding to those in `http_realworld_server.py`. After actual testing, it is indeed calling `step()` instead of `eval_action()`. 

<img width="1386" height="1032" alt="c52556d2-e1ce-451d-b24e-d85a839d5e80" src="https://github.com/user-attachments/assets/a85d9b61-d2b0-4642-bc96-ddb9a07bdc1c" />
<img width="1344" height="956" alt="5681162c-0471-4df6-8a8a-878e464824b7" src="https://github.com/user-attachments/assets/541e6de7-101a-4f9d-a318-5d63994ff2ea" />

Modification plan: In the file http_realworld_server.py, replace eval_action() with step(), and comment out depth and camera_pose.
Just like this
<img width="1239" height="675" alt="image" src="https://github.com/user-attachments/assets/344b2224-0059-457d-aea9-116581f7ada2" />

